### PR TITLE
Remove non-used mail from Malwine

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ notifications:
     recipients:
       - tobias.pfeiffer@student.hpi.uni-potsdam.de
       - locokaja@gmail.com
-      - graphicdiaryberlin@gmail.com
       - tils@tils.net
       - mail@lislis.de
       - rails-girls-berlin-project-group-tuesdays@googlegroups.com


### PR DESCRIPTION
Dear Rubycorns,
I would like to have this mail removed because I am not using it anymore.
Thanks :cat: 
Lost Rubycorn Malwine